### PR TITLE
init OCP helm charts

### DIFF
--- a/openshift/cit/.helmignore
+++ b/openshift/cit/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/openshift/cit/Chart.yaml
+++ b/openshift/cit/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cit
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/openshift/cit/templates/deployments.yaml
+++ b/openshift/cit/templates/deployments.yaml
@@ -1,0 +1,117 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: '8'
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "namespace": "{{ .Values.license_plate }}-tools",
+            "name": "{{ .Values.app_name }}-webapi:{{ .Values.image_stream_tag }}"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+  name: {{ .Values.app_name }}-api
+  namespace: {{ .Values.license_plate }}-{{ .Values.namespace_env }}
+  labels:
+    app: {{ .Values.app_name }}-api
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app_name }}-api
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app_name }}-api
+    spec:
+      containers:
+        - name: {{ .Values.app_name }}-api
+          image: {{ .Values.dockerhost }}/{{ .Values.license_plate }}-tools/{{ .Values.app_name }}-webapi:{{ .Values.image_stream_tag }}
+          resources:
+            limits:
+              cpu: {{ .Values.limits_cpu }}
+              memory: {{ .Values.limits_memory }}
+            requests:
+              cpu: {{ .Values.requests_cpu}}
+              memory: {{ .Values.requests_memory }}
+          terminationMessagePath: /dev/termination-log
+          envFrom:
+            - secretRef:
+                name: {{ .Values.app_name }}-api-config
+          imagePullPolicy: Always
+          terminationMessagePolicy: File
+      restartPolicy: Always
+      serviceAccount: default
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 600
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: '8'
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "namespace": "{{ .Values.license_plate }}-tools",
+            "name": "{{ .Values.app_name }}-frontend:{{ .Values.image_stream_tag }}"
+          },
+          "fieldPath": "spec.template.spec.containers[0].image"
+        }
+      ]
+  name: {{ .Values.app_name }}-web
+  namespace: {{ .Values.license_plate }}-{{ .Values.namespace_env }}
+  labels:
+    app: {{ .Values.app_name }}-web
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app_name }}-web
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app_name }}-web
+    spec:
+      containers:
+        - name: {{ .Values.app_name }}-web
+          image: {{ .Values.dockerhost }}/{{ .Values.license_plate }}-tools/{{ .Values.app_name }}-frontend:{{ .Values.image_stream_tag }}
+          resources:
+            limits:
+              cpu: {{ .Values.limits_cpu }}
+              memory: {{ .Values.limits_memory }}
+            requests:
+              cpu: {{ .Values.requests_cpu}}
+              memory: {{ .Values.requests_memory }}
+          terminationMessagePath: /dev/termination-log
+          envFrom:
+            - secretRef:
+                name: {{ .Values.app_name }}-web-config
+          imagePullPolicy: Always
+          terminationMessagePolicy: File
+          #volumeMounts:
+          #  - name: {{ .Values.app_name }}-nginx-cache
+          #    mountPath: /var/cache/nginx
+      restartPolicy: Always
+      serviceAccount: default
+      #volumes:
+      #  - name: {{ .Values.app_name }}-nginx-cache
+      #    emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 600

--- a/openshift/cit/templates/routes.yaml
+++ b/openshift/cit/templates/routes.yaml
@@ -1,0 +1,37 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ .Values.app_name }}-api
+  labels:
+    app: {{ .Values.app_name }}-api
+    name: {{ .Values.app_name }}-api
+spec:
+  port:
+    targetPort: 8080-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: {{ .Values.app_name }}-api
+    weight: 100
+  wildcardPolicy: None
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ .Values.app_name }}-web
+  labels:
+    app: {{ .Values.app_name }}-web
+    name: {{ .Values.app_name }}-web
+spec:
+  port:
+    targetPort: 8080-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: {{ .Values.app_name }}-web
+    weight: 100
+  wildcardPolicy: None

--- a/openshift/cit/templates/services.yaml
+++ b/openshift/cit/templates/services.yaml
@@ -1,0 +1,35 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Values.app_name }}-api
+  labels:
+    app: {{ .Values.app_name }}-api
+    name: {{ .Values.app_name }}-api
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: {{ .Values.app_name }}-api
+  sessionAffinity: None
+  type: ClusterIP
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Values.app_name }}-web
+  labels:
+    app: {{ .Values.app_name }}-web
+    name: {{ .Values.app_name }}-web
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: {{ .Values.app_name }}-web
+  sessionAffinity: None
+  type: ClusterIP

--- a/openshift/cit/values-dev.yaml
+++ b/openshift/cit/values-dev.yaml
@@ -1,0 +1,10 @@
+app_name: ciot
+license_plate: d2cb5f
+replicas: 1
+image_stream_tag: develop
+namespace_env: dev
+limits_cpu: 250m
+limits_memory: 512Mi
+requests_cpu: 150m
+requests_memory: 512Mi
+cluster: silver

--- a/openshift/ocp-common/Chart.yaml
+++ b/openshift/ocp-common/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cit
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/openshift/ocp-common/templates/default-service-account.yaml
+++ b/openshift/ocp-common/templates/default-service-account.yaml
@@ -1,0 +1,43 @@
+# this is not the entire service account as it should already exist as a default account created by the openshift team.
+# we do however need to modify it
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+    name: system:image-puller-default-dev
+    namespace: {{ .Values.license_plate }}-tools
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-puller
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Values.license_plate }}-dev
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+    name: system:image-puller-default-test
+    namespace: {{ .Values.license_plate }}-tools
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-puller
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Values.license_plate }}-test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+    name: system:image-puller-default-prod
+    namespace: {{ .Values.license_plate }}-tools
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:image-puller
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Values.license_plate }}-prod

--- a/openshift/ocp-common/templates/networkpolicy.yaml
+++ b/openshift/ocp-common/templates/networkpolicy.yaml
@@ -1,0 +1,138 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-all-internal
+  namespace: {{ .Values.license_plate }}-dev
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              environment: dev
+              name: {{ .Values.license_plate }}
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: {{ .Values.license_plate }}-dev
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-all-internal
+  namespace: {{ .Values.license_plate }}-test
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              environment: test
+              name: {{ .Values.license_plate }}
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: {{ .Values.license_plate }}-test
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-all-internal
+  namespace: {{ .Values.license_plate }}-prod
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              environment: prod
+              name: {{ .Values.license_plate }}
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: {{ .Values.license_plate }}-prod
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-all-internal
+  namespace: {{ .Values.license_plate }}-tools
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              environment: tools
+              name: {{ .Values.license_plate }}
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: {{ .Values.license_plate }}-tools
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: all-internamespace
+  namespace: {{ .Values.license_plate }}-tools
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ .Values.license_plate }}
+  policyTypes:
+    - Ingress

--- a/openshift/ocp-common/templates/rbac_admin.yaml
+++ b/openshift/ocp-common/templates/rbac_admin.yaml
@@ -1,0 +1,67 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admin_devops_engineers
+  namespace: {{ .Values.license_plate }}-dev
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: bashbang@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: jjstratton@github
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admin_devops_engineers
+  namespace: {{ .Values.license_plate }}-test
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: bashbang@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: jjstratton@github
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admin_devops_engineers
+  namespace: {{ .Values.license_plate }}-prod
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: bashbang@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: jjstratton@github
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admin_devops_engineers
+  namespace: {{ .Values.license_plate }}-tools
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: bashbang@github
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: jjstratton@github
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/openshift/ocp-common/templates/sysdig-team.yaml
+++ b/openshift/ocp-common/templates/sysdig-team.yaml
@@ -1,0 +1,15 @@
+apiVersion: ops.gov.bc.ca/v1alpha1
+kind: SysdigTeam
+metadata:
+  name: {{ .Values.license_plate }}-sysdigteam
+  namespace: {{ .Values.license_plate }}-tools
+spec:
+  team:
+    description: The Sysdig Team for GDX
+    users:
+    - name: Susan.Mordy@gov.bc.ca
+      role: ROLE_TEAM_MANAGER
+    - name: jessica.stratton@nttdata.com
+      role: ROLE_TEAM_EDIT
+    - name: chris@bashbang.com
+      role: ROLE_TEAM_MANAGER

--- a/openshift/ocp-common/values.yaml
+++ b/openshift/ocp-common/values.yaml
@@ -1,0 +1,1 @@
+license_plate: d2cb5f


### PR DESCRIPTION
Created the helm charts for ocp-common (network, rbac_admin, sysdig) and ciot helm chart for web/api deployments, services and routes.