### PR TITLE
Binding ports less than 1024 require root access.

### DIFF
--- a/ciot-web/nginx.conf
+++ b/ciot-web/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
 
     root   /usr/share/nginx/html;


### PR DESCRIPTION
Updated nginx.conf listen port to 8080